### PR TITLE
update jwt-simple to fix security advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "express": "^4.12.3",
     "https-proxy-agent": "^1.0.0",
     "js-sha256": "^0.3.0",
-    "jwt-simple": "^0.3.0",
+    "jwt-simple": "^0.5.6",
     "lodash": "^3.10.1",
     "log4js": "^0.6.27",
     "moment": "^2.10.2",


### PR DESCRIPTION
There is a Signature Verification Bypass vuln reported (https://www.npmjs.com/advisories/831).

Updating `jwt-simple` to fix this.